### PR TITLE
refactor: use lightweight math libs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,6 @@
         "formik": "^2.4.6",
         "jotai": "^2.12.5",
         "math-expression-evaluator": "^2.0.6",
-        "mathjs": "^14.4.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "typescript": "^5.8.3"
@@ -3752,18 +3751,6 @@
         "node": ">=4.0.0"
       }
     },
-    "node_modules/complex.js": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/complex.js/-/complex.js-2.4.2.tgz",
-      "integrity": "sha512-qtx7HRhPGSCBtGiST4/WGHuW+zeaND/6Ld+db6PbrulIB1i2Ev/2UPiqcmpQNPSyfBKraC0EOvOKCB5dGZKt3g==",
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/rawify"
-      }
-    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -3947,11 +3934,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/decimal.js": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
-      "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA=="
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -4308,11 +4290,6 @@
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "dev": true
-    },
-    "node_modules/escape-latex": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/escape-latex/-/escape-latex-1.2.0.tgz",
-      "integrity": "sha512-nV5aVWW1K0wEiUIEdZ4erkGGH8mDxGyxSeqPzRNtWP7ataw+/olFObw7hujFWlVjNsaDFw5VZ5NzVSIqRgfTiw=="
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -5129,18 +5106,6 @@
       "dev": true,
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/fraction.js": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.2.2.tgz",
-      "integrity": "sha512-uXBDv5knpYmv/2gLzWQ5mBHGBRk9wcKTeWu6GLTUEQfjCxO09uM/mHDrojlL+Q1mVGIIFo149Gba7od1XPgSzQ==",
-      "engines": {
-        "node": ">= 12"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/rawify"
       }
     },
     "node_modules/fresh": {
@@ -6030,11 +5995,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/javascript-natural-sort": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/javascript-natural-sort/-/javascript-natural-sort-0.7.1.tgz",
-      "integrity": "sha1-+eIwPUUH9tdDVac2ZNFED7Wg71k="
-    },
     "node_modules/jest-diff": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
@@ -6442,28 +6402,6 @@
       "dev": true,
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/mathjs": {
-      "version": "14.4.0",
-      "resolved": "https://registry.npmjs.org/mathjs/-/mathjs-14.4.0.tgz",
-      "integrity": "sha512-CpoYDhNENefjIG9wU9epr+0pBHzlaySfpWcblZdAf5qXik/j/U8eSmx/oNbmXO0F5PyfwPGVD/wK4VWsTho1SA==",
-      "dependencies": {
-        "@babel/runtime": "^7.26.10",
-        "complex.js": "^2.2.5",
-        "decimal.js": "^10.4.3",
-        "escape-latex": "^1.2.0",
-        "fraction.js": "^5.2.1",
-        "javascript-natural-sort": "^0.7.1",
-        "seedrandom": "^3.0.5",
-        "tiny-emitter": "^2.1.0",
-        "typed-function": "^4.2.1"
-      },
-      "bin": {
-        "mathjs": "bin/cli.js"
-      },
-      "engines": {
-        "node": ">= 18"
       }
     },
     "node_modules/media-typer": {
@@ -7421,11 +7359,6 @@
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
       "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA=="
     },
-    "node_modules/seedrandom": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-3.0.5.tgz",
-      "integrity": "sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg=="
-    },
     "node_modules/semver": {
       "version": "7.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
@@ -7948,11 +7881,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/tiny-emitter": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
-      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q=="
-    },
     "node_modules/tiny-warning": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
@@ -8175,14 +8103,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/typed-function": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/typed-function/-/typed-function-4.2.1.tgz",
-      "integrity": "sha512-EGjWssW7Tsk4DGfE+5yluuljS1OGYWiI1J6e8puZz9nTMM51Oug8CD5Zo4gWMsOhq5BI+1bF+rWTm4Vbj3ivRA==",
-      "engines": {
-        "node": ">= 18"
       }
     },
     "node_modules/typescript": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@types/react-dom": "^19.1.3",
         "formik": "^2.4.6",
         "jotai": "^2.12.5",
+        "math-expression-evaluator": "^2.0.6",
         "mathjs": "^14.4.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
@@ -6428,6 +6429,11 @@
       "dependencies": {
         "sourcemap-codec": "^1.4.8"
       }
+    },
+    "node_modules/math-expression-evaluator": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/math-expression-evaluator/-/math-expression-evaluator-2.0.6.tgz",
+      "integrity": "sha512-DRung1qNcKbgkhFeQ0fBPUFB6voRUMY7KyRyp1TRQ2v95Rp2egC823xLRooM1mDx1rmbkY7ym6ZWmpaE/VimOA=="
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "formik": "^2.4.6",
     "jotai": "^2.12.5",
     "math-expression-evaluator": "^2.0.6",
-    "mathjs": "^14.4.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "typescript": "^5.8.3"

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "@types/react-dom": "^19.1.3",
     "formik": "^2.4.6",
     "jotai": "^2.12.5",
+    "math-expression-evaluator": "^2.0.6",
     "mathjs": "^14.4.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/src/modules/simulator/index.ts
+++ b/src/modules/simulator/index.ts
@@ -1,16 +1,18 @@
-import { parser } from "mathjs";
+import Mexp from "math-expression-evaluator";
 import { Value } from "../../models";
 import { ISimulator } from "./interface";
 
 class Simulator implements ISimulator {
   // eslint-disable-next-line @typescript-eslint/class-methods-use-this
   public create = async (equation: string, x: number[]): Promise<Value[]> => {
-    const fx = parser();
-    fx.evaluate(`f(x) = ${equation}`);
+    const mexp = new Mexp();
     return Promise.all(
       x.map(async (xi) => {
         try {
-          const result = fx.evaluate(`f(${xi})`) as number | undefined;
+          // added parenthesis to miss replacing
+          // ex) expected: 5.01x -> 5.01 * 2.3, not to be: 5.1x -> 5.12.3 when x = 2.3)
+          const equationWithValue = equation.replace(/x/g, `(${(xi * 180) / Math.PI})`);
+          const result = mexp.eval(equationWithValue);
           if (typeof result === "number") {
             return { x: xi, y: result };
           }


### PR DESCRIPTION
replaced: mathjs -> math-expression-evaluator

```diff
- build/assets/index-ChYtZO5g.js   895.05 kB │ gzip: 266.42 kB
+ build/assets/index-tGz16wGo.js   253.92 kB │ gzip: 81.37 kB
```