### PR TITLE
fix: ensure loading UI renders before async simulation update

### DIFF
--- a/src/hooks/simulationState.ts
+++ b/src/hooks/simulationState.ts
@@ -25,21 +25,24 @@ export const useSimulationState = () => {
       isLoading: true,
     }));
 
-    try {
-      await controller.update(setting, state.setting);
-      setState((prev) => ({
-        ...prev,
-        setting,
-        error: undefined,
-        isLoading: false,
-      }));
-    } catch (e) {
-      setState((prev) => ({
-        ...prev,
-        error: e as Error,
-        isLoading: false,
-      }));
-    }
+    // wait isLoading ui update
+    setTimeout(async () => {
+      try {
+        await controller.update(setting, state.setting);
+        setState((prev) => ({
+          ...prev,
+          setting,
+          error: undefined,
+          isLoading: false,
+        }));
+      } catch (e) {
+        setState((prev) => ({
+          ...prev,
+          error: e as Error,
+          isLoading: false,
+        }));
+      }
+    }, 0);
   };
 
   return {


### PR DESCRIPTION
## Summary
• Fix loading UI rendering by wrapping controller.update() in setTimeout
• Ensures loading state is visible to users before async simulation computation begins

## Test plan
- [x] Verify loading indicator appears when changing simulation settings
- [x] Confirm simulation updates work correctly after the change
- [x] Test with complex equations that take time to compute

🤖 Generated with [Claude Code](https://claude.ai/code)