### PR TITLE
fix: uses variable substitution to improve performance (2x faster)

### DIFF
--- a/src/modules/simulator/index.ts
+++ b/src/modules/simulator/index.ts
@@ -13,15 +13,24 @@ class Simulator implements ISimulator {
 
   public create = async (equation: string, x: number[]): Promise<Value[]> => {
     const results: Value[] = [];
-    
+
     for (let i = 0; i < x.length; i++) {
       const xi = x[i]!; // Safe since we're iterating with i < x.length
       try {
-        // added parenthesis to miss replacing
-        // ex) expected: 5.01x -> 5.01 * 2.3, not to be: 5.1x -> 5.12.3 when x = 2.3)
         const xDegrees = xi * this.degreeConversionFactor;
-        const equationWithValue = equation.replace(/x/g, `(${xDegrees})`);
-        const result = this.mexp.eval(equationWithValue);
+        const result = this.mexp.eval(
+          equation,
+          [
+            {
+              type: 3,
+              show: "",
+              precedence: 1,
+              token: "x",
+              value: "x",
+            },
+          ],
+          { x: xDegrees },
+        );
         if (typeof result === "number") {
           results.push({ x: xi, y: result });
         } else {
@@ -31,7 +40,7 @@ class Simulator implements ISimulator {
         throw new Error(`Cannot eval: ${e}`);
       }
     }
-    
+
     return Promise.resolve(results);
   };
 }


### PR DESCRIPTION
measured with default chart: `f(x) = 2(sin(5.01x) + cos(4.99x))sin(10x)`
- as-is: 253 +- 1 ms
- to-be: 111 +- 1 ms